### PR TITLE
2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,5 @@ Compute distance between this transform and a transform `other`. Returns an obje
 	scale: abs(ds)
 }
 ```
+#### `t.tomat()`
+Return a [`mat3`](https://github.com/stackgl/gl-mat3) representation of the transform.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # transformist
 
-Simple transformations in the plane. A transform in two dimensions is defined here as a translation, a rotation, and a scaling. This module lets you specify this kind of transform and apply it, or its inverse, to one or more points. Methods are also provided for comparing and composing transforms. This is essentially wrapping [`mat3`](https://github.com/stackgl/gl-mat3) transforms with a friendlier API. Useful for 2D games and graphics.
+Simple transformations in the plane. A transform in two dimensions is defined here as a translation, a rotation, and a scaling. This module lets you specify this kind of transform and apply it, or its inverse, to one or more points. Methods are also provided for composing transforms and exporting as a matrix. This is essentially wrapping [`mat3`](https://github.com/stackgl/gl-mat3) transforms, but with an API that might seem friendlier. Useful for 2D games and graphics.
 
 [![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)
 

--- a/README.md
+++ b/README.md
@@ -54,28 +54,5 @@ Undo a transformation on one or more `points` of the form `[[x, y], [x, y]...]` 
 
 Compose this transform with a transform `other`, modifies in place. Translations and angles are added, scales are multiplied.
 
-#### `t.difference(other)`
-
-Compute difference between this transform and a transform `other`. Returns an object 
-
-```javascript
-{
-	translation: [dx, dy]
-	rotation: dr
-	scale: ds
-}
-```
-
-#### `t.distance(other)`
-
-Compute distance between this transform and a transform `other`. Returns an object
-
-```javascript
-{
-	translation: sqrt(dx^2 + dy^2)
-	rotation: abs(dr)
-	scale: abs(ds)
-}
-```
 #### `t.tomat()`
 Return a [`mat3`](https://github.com/stackgl/gl-mat3) representation of the transform.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # transformist
 
-Simple transformations in the plane. A transform in two dimensions is defined here as a translation, a rotation, and a scaling. This module lets you specify this kind of transform and apply it, or its inverse, to one or more points. Methods are also provided for comparing and composing transforms. Useful for 2D games and graphics.
+Simple transformations in the plane. A transform in two dimensions is defined here as a translation, a rotation, and a scaling. This module lets you specify this kind of transform and apply it, or its inverse, to one or more points. Methods are also provided for comparing and composing transforms. This is essentially wrapping [`mat3`](https://github.com/stackgl/gl-mat3) transforms with a friendlier API. Useful for 2D games and graphics.
 
 [![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)
 
@@ -52,7 +52,7 @@ Undo a transformation on one or more `points` of the form `[[x, y], [x, y]...]` 
 
 #### `t.compose(other)`
 
-Compose this transform with a transform `other`, modifies in place. Translations and angles are added, scales are multiplied.
+Compose this transform with a transform `other`, modifies in place. Equivalent to multiplying 3d transformation matrices.
 
 #### `t.tomat()`
 Return a [`mat3`](https://github.com/stackgl/gl-mat3) representation of the transform.

--- a/index.js
+++ b/index.js
@@ -24,28 +24,6 @@ Transform.prototype.compose = function (other) {
   return self
 }
 
-Transform.prototype.difference = function (other) {
-  var self = this
-  var dx = _.isArray(other.translation) ? other.translation[0] - self.translation[0] : 0
-  var dy = _.isArray(other.translation) ? other.translation[1] - self.translation[1] : 0
-  var dr = _.isNumber(other.rotation) ? other.rotation - self.rotation : 0
-  var ds = _.isNumber(other.scale) ? other.scale - self.scale : 0
-  return {
-    translation: [dx, dy],
-    rotation: dr,
-    scale: ds
-  }
-}
-
-Transform.prototype.distance = function (other) {
-  var d = this.difference(other)
-  return {
-    translation: Math.sqrt(Math.pow(d.translation[0], 2) + Math.pow(d.translation[1], 2)),
-    rotation: Math.abs(d.rotation),
-    scale: Math.abs(d.scale)
-  }
-}
-
 Transform.prototype.apply = function (points) {
   if (!_.isArray(points)) throw Error('Points must be an array')
   if (!_.isArray(points[0])) {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var _ = require('lodash')
+var mat3 = require('gl-mat3')
 
 module.exports = Transform
 
@@ -16,8 +17,10 @@ function Transform (opts) {
 
 Transform.prototype.compose = function (other) {
   var self = this
+  self.translation = Transform({rotation: other.rotation, scale: other.scale}).apply(self.translation)
   self.translation = _.isArray(other.translation)
-    ? [self.translation[0] + other.translation[0], self.translation[1] + other.translation[1]] : self.translation
+    ? [self.translation[0] + other.translation[0], self.translation[1] + other.translation[1]] 
+    : self.translation
   self.rotation = _.isNumber(other.rotation) ? self.rotation + other.rotation : self.rotation
   self.scale = _.isNumber(other.scale) ? self.scale * other.scale : self.scale
   self.rotmat = rotmat(self.rotation)

--- a/index.js
+++ b/index.js
@@ -92,6 +92,15 @@ Transform.prototype.invert = function (points) {
   return cleanup ? points[0] : points
 }
 
+Transform.prototype.tomat = function () {
+  var self = this
+  var mat = mat3.create()
+  mat3.translate(mat, mat, self.translation)
+  mat3.rotate(mat, mat, self.rotation * Math.PI / 180)
+  mat3.scale(mat, mat, [self.scale, self.scale])
+  return mat
+}
+
 function rotmat (angle) {
   var rad = angle * Math.PI / 180
   return [[Math.cos(rad), -Math.sin(rad)], [Math.sin(rad), Math.cos(rad)]]

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test-fuzzy-array": "^1.0.1"
   },
   "dependencies": {
+    "gl-mat3": "^1.0.0",
     "lodash": "^3.10.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,3 +1,4 @@
+var _ = require('lodash')
 var mat3 = require('gl-mat3')
 var test = require('tape')
 var allclose = require('test-allclose')
@@ -13,32 +14,48 @@ test('construction', function (t) {
 
 test('compose: translation', function (t) {
   var r1 = transform({translation: [1, 0]})
-  var r2 = transform({translation: [1, 2]})
-  allclose(t)(r1.compose(r2).translation, [2, 2])
+  var r2 = transform({translation: [0, 1]})
+  var r3 = r1.compose(r2)
+  allclose(t)(r3.translation, [1, 1])
   t.end()
 })
 
 test('compose: rotation', function (t) {
-  var r1 = transform({rotation: 20})
-  var r2 = transform({rotation: 30})
-  allclose(t)(r1.compose(r2).rotation, 50)
+  var r1 = transform({rotation: 45})
+  var r2 = transform({rotation: 45})
+  var r3 = r1.compose(r2)
+  allclose(t)(r3.rotation, 90)
   t.end()
 })
 
 test('compose: scale', function (t) {
   var r1 = transform({scale: 2})
   var r2 = transform({scale: 3})
-  allclose(t)(r1.compose(r2).scale, 6)
+  var r3 = r1.compose(r2)
+  allclose(t)(r3.scale, 6)
   t.end()
 })
 
 test('compose: all', function (t) {
-  var r1 = transform({translation: [1, 0], rotation: 20, scale: 2})
-  var r2 = transform({translation: [1, 2], rotation: 30, scale: 3})
+  var r1 = transform({translation: [1, 0], rotation: 90})
+  var r2 = transform({translation: [0, 1], rotation: 90})
   var r3 = r1.compose(r2)
-  allclose(t)(r3.translation, [2, 2])
-  allclose(t)(r3.rotation, 50)
-  allclose(t)(r3.scale, 6)
+  allclose(t)(r3.translation, [0, 2])
+  allclose(t)(r3.rotation, 180)
+  allclose(t)(r3.apply([0, 1]), [0, 1])
+  t.end()
+})
+
+test('compose: matrices', function (t) {
+  var r1 = transform({translation: [1, 0], rotation: 90})
+  var r2 = transform({translation: [0, 1], rotation: 90})
+  var m1 = r1.tomat()
+  var m2 = r2.tomat()
+  var r3 = r1.compose(r2)
+  var m3 = r3.tomat()
+  var m3test = mat3.create()
+  var m3test = mat3.multiply(m3, m2, m1)
+  allclose(t)(_.values(m3), _.values(m3test))
   t.end()
 })
 

--- a/test.js
+++ b/test.js
@@ -1,3 +1,4 @@
+var mat3 = require('gl-mat3')
 var test = require('tape')
 var allclose = require('test-allclose')
 var transform = require('./index.js')
@@ -168,6 +169,9 @@ test('distance: translation', function (t) {
   var r3 = transform({translation: [-1, 0]})
   allclose(t)(r1.distance(r2).translation, 1)
   allclose(t)(r1.distance(r3).translation, 1)
+test('mat: translation', function (t) {
+  var r = transform({translation: [1, 2]})
+  allclose(t)(_.values(r.tomat()), [1, 0, 0, 0, 1, 0, 1, 2, 1])
   t.end()
 })
 
@@ -177,6 +181,9 @@ test('distance: rotation', function (t) {
   var r3 = transform({rotation: -10})
   allclose(t)(r1.distance(r2).rotation, 10)
   allclose(t)(r1.distance(r3).rotation, 10)
+test('mat: rotation', function (t) {
+  var r = transform({rotation: 180})
+  allclose(t)(_.values(r.tomat()), [-1, 0, 0, 0, -1, 0, 0, 0, 1])
   t.end()
 })
 
@@ -186,6 +193,9 @@ test('distance: scale', function (t) {
   var r3 = transform({scale: 0.9})
   allclose(t)(r1.distance(r2).scale, 0.1)
   allclose(t)(r1.distance(r3).scale, 0.1)
+test('mat: scale', function (t) {
+  var r = transform({scale: 3})
+  allclose(t)(_.values(r.tomat()), [3, 0, 0, 0, 3, 0, 0, 0, 1])
   t.end()
 })
 
@@ -198,5 +208,8 @@ test('update', function (t) {
   var c = r.apply([0, 0])
   var d = [1, 3]
   allclose(t)(c, d)
+test('mat: combined', function (t) {
+  var r = transform({translation: [1, 2], rotation: 180, scale: 3})
+  allclose(t)(_.values(r.tomat()), [-3, 0, 0, 0, -3, 0, 1, 2, 1])
   t.end()
 })

--- a/test.js
+++ b/test.js
@@ -136,69 +136,6 @@ test('invert: roundtrip backwards', function (t) {
   t.end()
 })
 
-test('difference: translation', function (t) {
-  var r1 = transform({translation: [0, 0]})
-  var r2 = transform({translation: [0, 1]})
-  var r3 = transform({translation: [-1, 0]})
-  allclose(t)(r1.difference(r2).translation, [0, 1])
-  allclose(t)(r1.difference(r3).translation, [-1, 0])
-  t.end()
-})
-
-test('difference: rotation', function (t) {
-  var r1 = transform({rotation: 0})
-  var r2 = transform({rotation: 10})
-  var r3 = transform({rotation: -10})
-  allclose(t)(r1.difference(r2).rotation, 10)
-  allclose(t)(r1.difference(r3).rotation, -10)
-  t.end()
-})
-
-test('difference: scale', function (t) {
-  var r1 = transform({scale: 1})
-  var r2 = transform({scale: 1.1})
-  var r3 = transform({scale: 0.9})
-  allclose(t)(r1.difference(r2).scale, 0.1)
-  allclose(t)(r1.difference(r3).scale, -0.1)
-  t.end()
-})
-
-test('distance: translation', function (t) {
-  var r1 = transform({translation: [0, 0]})
-  var r2 = transform({translation: [0, 1]})
-  var r3 = transform({translation: [-1, 0]})
-  allclose(t)(r1.distance(r2).translation, 1)
-  allclose(t)(r1.distance(r3).translation, 1)
-test('mat: translation', function (t) {
-  var r = transform({translation: [1, 2]})
-  allclose(t)(_.values(r.tomat()), [1, 0, 0, 0, 1, 0, 1, 2, 1])
-  t.end()
-})
-
-test('distance: rotation', function (t) {
-  var r1 = transform({rotation: 0})
-  var r2 = transform({rotation: 10})
-  var r3 = transform({rotation: -10})
-  allclose(t)(r1.distance(r2).rotation, 10)
-  allclose(t)(r1.distance(r3).rotation, 10)
-test('mat: rotation', function (t) {
-  var r = transform({rotation: 180})
-  allclose(t)(_.values(r.tomat()), [-1, 0, 0, 0, -1, 0, 0, 0, 1])
-  t.end()
-})
-
-test('distance: scale', function (t) {
-  var r1 = transform({scale: 1})
-  var r2 = transform({scale: 1.1})
-  var r3 = transform({scale: 0.9})
-  allclose(t)(r1.distance(r2).scale, 0.1)
-  allclose(t)(r1.distance(r3).scale, 0.1)
-test('mat: scale', function (t) {
-  var r = transform({scale: 3})
-  allclose(t)(_.values(r.tomat()), [3, 0, 0, 0, 3, 0, 0, 0, 1])
-  t.end()
-})
-
 test('update', function (t) {
   var r = transform({translation: [1, 2]})
   var a = r.apply([0, 0])
@@ -208,6 +145,27 @@ test('update', function (t) {
   var c = r.apply([0, 0])
   var d = [1, 3]
   allclose(t)(c, d)
+  t.end()
+})
+
+test('mat: translation', function (t) {
+  var r = transform({translation: [1, 2]})
+  allclose(t)(_.values(r.tomat()), [1, 0, 0, 0, 1, 0, 1, 2, 1])
+  t.end()
+})
+
+test('mat: rotation', function (t) {
+  var r = transform({rotation: 180})
+  allclose(t)(_.values(r.tomat()), [-1, 0, 0, 0, -1, 0, 0, 0, 1])
+  t.end()
+})
+
+test('mat: scale', function (t) {
+  var r = transform({scale: 3})
+  allclose(t)(_.values(r.tomat()), [3, 0, 0, 0, 3, 0, 0, 0, 1])
+  t.end()
+})
+
 test('mat: combined', function (t) {
   var r = transform({translation: [1, 2], rotation: 180, scale: 3})
   allclose(t)(_.values(r.tomat()), [-3, 0, 0, 0, -3, 0, 1, 2, 1])


### PR DESCRIPTION
Fixes a bug in the implementation of `compose`, removes methods that don't really belong because they lack clear corresponding geometric operators (e.g. `add`, `difference`, and `distance`) and adds export of a `mat3` in the `tomat()` method.
